### PR TITLE
Disable release by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - if: false # Remove when ready to release
       - uses: actions/checkout@v2
 
       - id: tag

--- a/README.md
+++ b/README.md
@@ -2,14 +2,25 @@
 
 Haskell library template used at Freckle.
 
-```
+## Create your repo
+
+```sh
 gh repo create --template freckle/haskell-library-template
 ```
 
-Setup your repo/package name
+## Rename your package
 
-```
+```sh
 sed -i s/haskell-library-template/my-name/ **/*
+```
+
+## Enable release
+
+When you are ready to release your library, simply remove the conditional from
+the release workflow.
+
+```diff
+--      - if: false # Remove when ready to release
 ```
 
 ---

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: haskell-library-template
-version: 1.0.4.0
+version: 0.0.0.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/haskell-library-template


### PR DESCRIPTION
When starting a library it is not often ready for release. This change
allows the library author to control when release is initiated by
removing a simple if statement.