### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
         uses: freckle/stack-action@v5
         env:
           STACK_YAML: ${{ matrix.stack-yaml }}
-      - if: ${{ matrix.stack-yaml == 'stack.yaml' }}
-        uses: freckle/weeder-action@v2
-        with:
-          ghc-version: ${{ steps.stack.outputs.compiler-version }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - uses: actions/checkout@v4
       - id: stack
         uses: freckle/stack-action@v5
-        with:
-          stack-yaml: ${{ matrix.stack-yaml }}
+        env:
+          STACK_YAML: ${{ matrix.stack-yaml }}
       - if: ${{ matrix.stack-yaml == 'stack.yaml' }}
         uses: freckle/weeder-action@v2
         with:

--- a/weeder.toml
+++ b/weeder.toml
@@ -1,2 +1,0 @@
-roots = ["Main.main", "^Paths_.*"]
-type-class-roots = true


### PR DESCRIPTION
- Specify stack yaml path by environment variable to fix deprecation warning
- Remove weeder; as previously discussed, it is not very useful for libraries, since the whole point is to provide a collection of utilities that are not used by the library itself.
